### PR TITLE
Sam-test

### DIFF
--- a/unpackaged/main/default/objects/Account/fields/SLASerialNumber__c.field-meta.xml
+++ b/unpackaged/main/default/objects/Account/fields/SLASerialNumber__c.field-meta.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>SLASerialNumber__c</fullName>
-    <description>Capture the 5 digit long serial number for the user&#39;s SLA</description>
     <externalId>false</externalId>
     <label>SLA Serial Number</label>
-    <length>5</length>
+    <length>10</length>
     <required>false</required>
     <trackFeedHistory>false</trackFeedHistory>
     <type>Text</type>


### PR DESCRIPTION
This PR includes an update to the metadata for the custom field `SLASerialNumber__c` in the `Account` object. Below is a detailed breakdown of the changes made:

---

## 1. `SLASerialNumber__c.field-meta.xml`
**Changes:**
- The `description` element has been removed.
- The `length` of the field has been changed from `5` to `10`.

**Impact:**
- **Removal of Description:** The absence of a description may affect user understanding of the field's purpose in the UI. It is advisable to ensure that users are aware of the field's intended use, possibly through other documentation or training.
- **Change in Length:** Increasing the length of the `SLASerialNumber__c` field from `5` to `10` allows for longer serial numbers to be stored. This change may impact existing data if there are any records that were previously validated against the 5-character limit. Ensure that any integrations or processes that interact with this field are updated accordingly to handle the new length.

---

## Summary
This PR introduces a key update to the `SLASerialNumber__c` field:
- The field's length has been increased to accommodate longer serial numbers.
- The description has been removed, which may require additional communication to users.

Testing should focus on:
1. Verifying that the field can now accept serial numbers up to 10 characters long without issues.
2. Ensuring that any existing data is still valid and accessible after the change.
3. Confirming that any user interfaces or reports that utilize this field are functioning correctly.

DSCP-7